### PR TITLE
Fix File.exists? call on binstub check

### DIFF
--- a/plugin/ruby.vim
+++ b/plugin/ruby.vim
@@ -119,7 +119,7 @@ class RubyTest
   end
 
   def spec_command
-    if File.exists('./bin/rspec')
+    if File.exists?('./bin/rspec')
       './bin/rspec'
     elsif File.exists?("Gemfile") && match = `bundle show rspec`.match(/(\d+\.\d+\.\d+)$/)
       match.to_a.last.to_f < 2 ? "bundle exec spec" : "bundle exec rspec"


### PR DESCRIPTION
The current master branch calls a nonexistent method `File.exists`, without the question mark. This causes an error for me. Attached commit fixes the issue.
