### PR TITLE
Added rspec-core as gem option to make it compatible with rspec-rails and possibly others

### DIFF
--- a/plugin/ruby.vim
+++ b/plugin/ruby.vim
@@ -128,7 +128,7 @@ class RubyTest
       'zeus rspec'
     elsif File.exists?('./bin/rspec')
       './bin/rspec'
-    elsif File.exists?("Gemfile") && match = `bundle show rspec`.match(/(\d+\.\d+\.\d+)$/)
+    elsif File.exists?("Gemfile") && (match = `bundle show rspec`.match(/(\d+\.\d+\.\d+)$/i) || match = `bundle show rspec-core`.match(/(\d+\.\d+\.\d+)$/))
       match.to_a.last.to_f < 2 ? "bundle exec spec" : "bundle exec rspec"
     else
       system("rspec -v > /dev/null 2>&1") ? "rspec --no-color" : "spec"


### PR DESCRIPTION
I just created a rails project and added rspec-rails (https://github.com/rspec/rspec-rails) in the Gemfile and the vim plugin wasn't working because the "bundle show rspec" wasn't able to find it since rspec-rails doesn't have rspec as dependency - it has rspec-core instead.
