### PR TITLE
Fixed error in running shoulda context

### DIFF
--- a/plugin/ruby.vim
+++ b/plugin/ruby.vim
@@ -119,8 +119,8 @@ class RubyTest
       if spec_file?
         send_to_vimux("#{spec_command} #{current_file} -l #{context_line_number}")
       else
-        method_name = "\"/#{Regexp.escape(method_name)}/\""
-        send_to_vimux("#{ruby_command} #{current_file} -n #{method_name}")
+        method_name = Regexp.escape(method_name)
+        send_to_vimux("#{ruby_command} #{current_file} -n /'#{method_name}'/")
       end
     end
   end


### PR DESCRIPTION
Running shoulda context gives an error because method name [here](https://github.com/pgr0ss/vimux-ruby-test/blob/master/plugin/ruby.vim#L122) is enclosed in double quotes which is passed to send_to_vimux [here](https://github.com/pgr0ss/vimux-ruby-test/blob/master/plugin/ruby.vim#L149) which is also in double quotes.

This fix uses single quotes in method name for this vimux call to work:

``` vim
Vim.command("call RunVimTmuxCommand(\"clear && #{test_command}\")")
```
