### PR TITLE
Check if rspec-core exists to support newer versions of rspec.

### DIFF
--- a/plugin/ruby.vim
+++ b/plugin/ruby.vim
@@ -138,7 +138,7 @@ class RubyTest
       'zeus rspec'
     elsif File.exists?('./bin/rspec')
       './bin/rspec'
-    elsif File.exists?("Gemfile") && (match = `bundle show rspec`.match(/(\d+\.\d+\.\d+)$/i) || match = `bundle show rspec-core`.match(/(\d+\.\d+\.\d+)$/))
+    elsif File.exists?("Gemfile") && (match = `bundle show rspec-core`.match(/(\d+\.\d+\.\d+)$/) || match = `bundle show rspec`.match(/(\d+\.\d+\.\d+)$/i))
       match.to_a.last.to_f < 2 ? "bundle exec spec" : "bundle exec rspec"
     else
       system("rspec -v > /dev/null 2>&1") ? "rspec --no-color" : "spec"


### PR DESCRIPTION
When running `bundle show rspec` bundle expects user input which causes vim to lock up. Checking for rspec-core first solves this issue.
