### PR TITLE
Add configuration option for not clearing console before test run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ let g:vimux_ruby_cmd_all_tests = "testdrb"
 let g:vimux_ruby_cmd_context = "FOO=bar ruby"
 ```
 
+By default, vim-ruby-test clears the tmux pane in which the command is run. You can configure
+this behavior:
+
+```vim
+let g:vimux_ruby_clear_console_on_run = 0
+```
+
 INSTALL
 ====================
 
@@ -48,3 +55,4 @@ CONTRIBUTORS:
 - [Drew Olson](https://github.com/drewolson)
 - [Paul Gross](https://github.com/pgr0ss)
 - [Kendall Buchanan](https://github.com/kendagriff)
+- [Thomas Mayfield](https://github.com/thegreatape)

--- a/plugin/ruby.vim
+++ b/plugin/ruby.vim
@@ -16,6 +16,9 @@ endif
 if !exists("g:vimux_ruby_cmd_context")
   let g:vimux_ruby_cmd_context = "ruby"
 endif
+if !exists("g:vimux_ruby_clear_console_on_run")
+  let g:vimux_ruby_clear_console_on_run = 1
+endif
 
 command RunAllRubyTests :call s:RunAllRubyTests()
 command RunAllRailsTests :call s:RunAllRailsTests()
@@ -146,7 +149,13 @@ class RubyTest
   end
 
   def send_to_vimux(test_command)
-    Vim.command("call VimuxRunCommand(\"clear && #{test_command}\")")
+    cmd = if VIM::evaluate("g:vimux_ruby_clear_console_on_run") != 0
+      "clear && "
+    else
+      ''
+    end
+    cmd += test_command
+    Vim.command("call VimuxRunCommand(\"#{cmd}\")")
   end
 end
 EOF


### PR DESCRIPTION
I prefer not to have the "clear && " prepended to my test commands, so I added a configuration option for it. Thanks for creating this plugin!
