### PR TITLE
Allow rspec beta versions to match

### DIFF
--- a/plugin/ruby.vim
+++ b/plugin/ruby.vim
@@ -141,7 +141,7 @@ class RubyTest
       'zeus rspec'
     elsif File.exists?('./bin/rspec')
       './bin/rspec'
-    elsif File.exists?("Gemfile") && (match = `bundle show rspec-core`.match(/(\d+\.\d+\.\d+)$/) || match = `bundle show rspec`.match(/(\d+\.\d+\.\d+)$/i))
+    elsif File.exists?("Gemfile") && (match = `bundle show rspec-core`.match(/(\d+\.\d+\.\d+)/) || match = `bundle show rspec`.match(/(\d+\.\d+\.\d+)/i))
       match.to_a.last.to_f < 2 ? "bundle exec spec" : "bundle exec rspec"
     else
       system("rspec -v > /dev/null 2>&1") ? "rspec --no-color" : "spec"


### PR DESCRIPTION
Currently, rspec beta versions like `rspec-core-3.0.0.beta2` don't match the first regex for rspec version detection and fall through to the second. The second, however, will cause recent rspec versions to prompt for user input and hang vim as a result.

This pull request removes the requirement that the version is last in the string, which allows `rspec-core-3.0.0.beta2` to match appropriately.
