### PR TITLE
Fix regexp for matching rspec

### DIFF
--- a/plugin/ruby.vim
+++ b/plugin/ruby.vim
@@ -141,7 +141,7 @@ class RubyTest
       'zeus rspec'
     elsif File.exists?('./bin/rspec')
       './bin/rspec'
-    elsif File.exists?("Gemfile") && (match = `bundle show rspec-core`.match(/(\d+\.\d+\.\d+)/) || match = `bundle show rspec`.match(/(\d+\.\d+\.\d+)/i))
+    elsif File.exists?("Gemfile") && (match = `bundle show rspec-core`.match(/(\d+\.\d+\.\d+)$/) || match = `bundle show rspec`.match(/(\d+\.\d+\.\d+)$/i))
       match.to_a.last.to_f < 2 ? "bundle exec spec" : "bundle exec rspec"
     else
       system("rspec -v > /dev/null 2>&1") ? "rspec --no-color" : "spec"


### PR DESCRIPTION
As bundle show rspec-core return place where user has installed rspec-core,
it will return something like:
- /home/username/.gem/ruby/1.9.3/gems/rspec-core-2.14.5

In this case it will match 1.9.3 as the rspec version, what is wrong.
