### PR TITLE
Allow relative paths for file arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ this behavior:
 let g:vimux_ruby_clear_console_on_run = 0
 ```
 
+By default, vim-ruby-test uses the absolute path for file arguments. You can configure it to instead use relative paths with:
+
+```vim
+let g:vimux_ruby_file_relative_paths = 1
+```
+
 INSTALL
 ====================
 

--- a/plugin/ruby.vim
+++ b/plugin/ruby.vim
@@ -30,23 +30,23 @@ command RunRailsFocusedTest :call s:RunRailsFocusedTest()
 command RunRubyFocusedContext :call s:RunRubyFocusedContext()
 
 function s:RunAllRubyTests()
-  ruby RubyTest.new.run_all(false, Vim.evaluate('g:vimux_ruby_cmd_all_tests'), Vim.evaluate('g:vimux_ruby_file_relative_paths'))
+  ruby RubyTest.create_from_settings.run_all
 endfunction
 
 function s:RunAllRailsTests()
-  ruby RubyTest.new.run_all(true, Vim.evaluate('g:vimux_ruby_cmd_all_tests'), Vim.evaluate('g:vimux_ruby_file_relative_paths'))
+  ruby RubyTest.create_from_settings.run_all(true)
 endfunction
 
 function s:RunRubyFocusedTest()
-  ruby RubyTest.new.run_test(false, Vim.evaluate('g:vimux_ruby_cmd_unit_test'), Vim.evaluate('g:vimux_ruby_file_relative_paths'))
+  ruby RubyTest.create_from_settings.run_test
 endfunction
 
 function s:RunRailsFocusedTest()
-  ruby RubyTest.new.run_test(true, Vim.evaluate('g:vimux_ruby_cmd_unit_test'), Vim.evaluate('g:vimux_ruby_file_relative_paths'))
+  ruby RubyTest.create_from_settings.run_test(true)
 endfunction
 
 function s:RunRubyFocusedContext()
-  ruby RubyTest.new.run_context(Vim.evaluate('g:vimux_ruby_cmd_context'), Vim.evaluate('g:vimux_ruby_file_relative_paths'))
+  ruby RubyTest.create_from_settings.run_context
 endfunction
 
 ruby << EOF
@@ -59,12 +59,20 @@ module VIM
 end
 
 class RubyTest
-  def initialize
-    @use_relative_path = false
+  attr_reader :ruby_command
+  attr_reader :use_relative_path
+
+  def self.create_from_settings
+    self.new(Vim.evaluate('g:vimux_ruby_cmd_all_tests'), Vim.evaluate('g:vimux_ruby_file_relative_paths'))
+  end
+
+  def initialize(ruby_command, use_relative_path)
+    @ruby_command = ruby_command
+    @use_relative_path = use_relative_path
   end
 
   def current_file
-    @use_relative_path == 0 ? VIM::Buffer.current.name : Vim.evaluate('expand("%")')
+    use_relative_path == 0 ? VIM::Buffer.current.name : Vim.evaluate('expand("%")')
   end
 
   def rails_test_dir
@@ -83,8 +91,7 @@ class RubyTest
     send_to_vimux("#{spec_command} #{current_file}:#{line_number}")
   end
 
-  def run_unit_test(rails=false, ruby_command='ruby', use_relative_path=false)
-    @use_relative_path = use_relative_path
+  def run_unit_test(rails=false)
     method_name = nil
 
     (line_number + 1).downto(1) do |line_number|
@@ -105,17 +112,15 @@ class RubyTest
     send_to_vimux("#{ruby_command} #{"-I #{rails_test_dir} " if rails}#{current_file} -n #{method_name}") if method_name
   end
 
-  def run_test(rails=false, ruby_command='ruby', use_relative_path=false)
-    @use_relative_path = use_relative_path
+  def run_test(rails=false)
     if spec_file?
       run_spec
     else
-      run_unit_test(rails, ruby_command)
+      run_unit_test(rails)
     end
   end
 
-  def run_context(ruby_command='ruby', use_relative_path=false)
-    @use_relative_path = use_relative_path
+  def run_context
     method_name = nil
     context_line_number = nil
 
@@ -138,8 +143,7 @@ class RubyTest
     end
   end
 
-  def run_all(rails=false, ruby_command='ruby', use_relative_path=false)
-    @use_relative_path = use_relative_path
+  def run_all(rails=false)
     if spec_file?
       send_to_vimux("#{spec_command} '#{current_file}'")
     else


### PR DESCRIPTION
Currently for focused or single-file tests, this plugin uses the absolute path to the file as the argument. In some cases this doesn't work, e.g. if your code is running in a Vagrant VM.

This PR adds a global config option to always use relative filepaths as arguments to rspec.

The default behavior is unchanged, it still uses absolute paths.