### PR TITLE
let color defaults have precedence

### DIFF
--- a/plugin/ruby.vim
+++ b/plugin/ruby.vim
@@ -163,7 +163,7 @@ class RubyTest
     elsif File.exists?("Gemfile") && (match = `bundle show rspec-core`.scan(RSPEC_VERSION_REGEX) || match = `bundle show rspec`.scan(RSPEC_VERSION_REGEX))
       match.flatten.last.to_f < 2 ? "bundle exec spec" : "bundle exec rspec"
     else
-      system("rspec -v > /dev/null 2>&1") ? "rspec --no-color" : "spec"
+      system("rspec -v > /dev/null 2>&1") ? "rspec" : "spec"
     end
   end
 


### PR DESCRIPTION
removes the `--no-color` flag from the ternary in the case that there is no Gemfile