### PR TITLE
Fix compatability with neovim

### DIFF
--- a/plugin/ruby.vim
+++ b/plugin/ruby.vim
@@ -50,14 +50,6 @@ function s:RunRubyFocusedContext()
 endfunction
 
 ruby << EOF
-module VIM
-  class Buffer
-    def method_missing(method, *args, &block)
-      VIM.command "#{method} #{self.name}"
-    end
-  end
-end
-
 class RubyTest
   RSPEC_VERSION_REGEX = /(\d+\.\d+\.\d+)/
 


### PR DESCRIPTION
An error is thrown when trying to use `vimux-ruby-test` in neovim. The error that is raised is
```
Error detected while processing function provider#ruby#Call:
line   17:
Invalid channel: 1
```

I was able to track the issue down to the `method_missing` on `VIM::Buffer`. I tested this change using neovim and vim.